### PR TITLE
startとendをUnixtimeの1000倍(ミリ秒)に修正

### DIFF
--- a/epgdump.c
+++ b/epgdump.c
@@ -485,8 +485,8 @@ void dumpJSON(FILE *outfile)
 			}
 			fprintf(outfile,"],");
 
-			fprintf(outfile,"\"start\":%d0000,",eitcur->start_time);
-			fprintf(outfile,"\"end\":%d0000,",eitcur->start_time+eitcur->duration);
+			fprintf(outfile,"\"start\":%d000,",eitcur->start_time);
+			fprintf(outfile,"\"end\":%d000,",eitcur->start_time+eitcur->duration);
 			fprintf(outfile,"\"duration\":%d,",eitcur->duration);
 
 			eitextcanma="";


### PR DESCRIPTION
JavaScriptのDataオブジェクトは1970年1月1日0時0分0秒からの経過ミリ秒([Date - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Date))であるがjson出力の際にstartとendでUnixtimeの1万倍を出力していたものの修正